### PR TITLE
Basic enhancements

### DIFF
--- a/tfjsod.html
+++ b/tfjsod.html
@@ -38,6 +38,13 @@
                 <label for="node-input-annotationExpression"><i class="fa fa-picture-o"></i> Annotation</label>
                 <input type="text" id="node-input-annotationExpression">
             </div>
+            <div class="form-row" id="node-annotationBackground">
+                <label for="node-input-annotationBackground"><i class="fa fa-square"></i> Background</label>
+                <select type="text" id="node-input-annotationBackground" style="width:70%;">
+                    <option value="none">None</option>
+                    <option value="rect">Filled rectangle</option>
+                </select>
+            </div>
             <div class="form-row" id="node-bbox-padding">
                 <label for="node-input-bboxPadding"><i class="fa fa-window-close-o"></i> Padding</label>
                 <input type="number" id="node-input-bboxPadding" min="0">
@@ -57,7 +64,7 @@
         <div id="node-tfjsod-tab-filters">
             <div class="form-row">
                 <label for="node-input-minimumScore"><i class="fa fa-signal"></i> Min. score</label>
-                <input type="number" id="node-input-minimumScore" placeholder="e.g. 0 - 1" min="0" max="1" step="0.1">
+                <input type="number" id="node-input-minimumScore" placeholder="e.g. 0 - 1" min="0" max="1" step=".01">
             </div>
             <div class="form-row">
                 <label for="node-input-minimumWidth"><i class="fa fa-arrows-h"></i> Min. width</label>
@@ -77,11 +84,11 @@
             </div>
             <div class="form-row">
                 <label for="node-input-minimumAspectRatio"><i class="fa fa-arrows"></i> Min. aspect ratio</label>
-                <input type="number" id="node-input-minimumAspectRatio" min="0">
+                <input type="number" id="node-input-minimumAspectRatio" min="0" step=".01">
             </div>
             <div class="form-row">
                 <label for="node-input-maximumAspectRatio"><i class="fa fa-arrows"></i> Max. aspect ratio</label>
-                <input type="number" id="node-input-maximumAspectRatio" min="0">
+                <input type="number" id="node-input-maximumAspectRatio" min="0" step=".01">
             </div>
             <div class="form-row">
                 <label for="node-input-maximumDetections"><i class="fa fa-level-down "></i> Max. detections</label>
@@ -146,6 +153,7 @@
             inputFormat: { value: "jpg" },
             passthru: { value: "none" },
             annotationExpression: { value: "{{class}}({{scorePercentage}})" },
+            annotationBackground: { value: "none" },
             bboxPadding: { value: 0 },
             lineColor: { value: "#FF00FF" }, // Magenta
             outputFormat: { value: "jpg" }
@@ -302,7 +310,6 @@ debugger
                 types:['json']
             });
             //$("#node-input-classFilterType").typedInput('type', node.classFilterType);
-debugger;
             // Show tabsheets
             node.tabs = RED.tabs.create({
                 id: "node-tfjsod-tabs",


### PR DESCRIPTION
Hi @dceejay,

Some basic enhancements:

1. Extra option for annotation label background, to draw a colored rectangle behind a white annotation label.  Which makes it easier for me to see the annotation labels, on backgrounds with different background colors (e.g. in garden):

   ![image](https://github.com/dceejay/tfjs-object-detection/assets/14224149/35ff2af6-bcd4-418e-9896-8e1e224a4664)

2. Fix to allow filter values < 1 (for score and aspect ratio).

3. No bbox drawing code triggered (more specifically rgb to rgba) if no objects detected.  Because at 6 fps I already had quite some cpu usage on a Raspberry Pi 4 while no objects were being detected:

   ![image](https://github.com/dceejay/tfjs-object-detection/assets/14224149/a95b53ac-18dd-4dbe-90a5-1f697f62c782)

   After applying this fix, cpu usage is quite a lot lower ***when*** no objects are being detected:

   ![image](https://github.com/dceejay/tfjs-object-detection/assets/14224149/306a9257-e0d2-43be-a8a4-ddc4517f4d75)

   Although of course this won't help while objects are being detected, because then the bbox drawing code will be triggered anyway.

4. Fix to make sure that bboxes with padding (!!) are constrained to the image dimensions, because the padding was not taken into account until now.

5. When there is not enough room above a bbox, then the annotation label is drawn automatically below the bbox:

   ![image](https://github.com/dceejay/tfjs-object-detection/assets/14224149/6d105afa-79fd-46c3-b203-12cd986837b7)

6. Print the stacktrace in the console log in case of an exception.

7. The execution times in the output message have become more fine grained, by adding rgb-to-rgba and rgba-to-rgb conversions as separate entries:

   ![image](https://github.com/dceejay/tfjs-object-detection/assets/14224149/caa8d7e3-ff76-4b60-b5fc-365abac58613)

Bart